### PR TITLE
fix invisible search-bar input on Firefox

### DIFF
--- a/css/donut.css
+++ b/css/donut.css
@@ -1750,7 +1750,8 @@ header#nav-header {
 }
 .side-search-bar .qa-search-field.form-control {
   border-radius: 4px;
-  padding: 20px 12px;
+  padding: 10px 12px;
+  height: auto;
 }
 .donut-top {
   display: inline-block;


### PR DESCRIPTION
This will fix the search-bar input issue on Firefox. The search-bar text input is not visible to the user who types in. The issue is very similar to the one on http://stackoverflow.com/questions/24448991/input-padding-cutting-out-text-in-firefox