### PR TITLE
Fix errors in structured data

### DIFF
--- a/qa-theme/Donut-theme/qa-donut-layer.php
+++ b/qa-theme/Donut-theme/qa-donut-layer.php
@@ -221,6 +221,9 @@
             $this->output( '</div>' );
             $this->output( '</div>' );
 
+            $extratags = isset($this->content['wrapper_tags']) ? $this->content['wrapper_tags'] : '';
+            $this->output( '<div class="qa-body-wrapper"' . $extratags . '>', '' );
+
             $this->output( '<main class="donut-masthead">' );
 
             $this->output( '<div class="container">' );
@@ -240,7 +243,7 @@
 
             $this->output( '</main>' );
 
-            $this->output( '<div class="qa-body-wrapper container">', '' );
+            $this->output( '<div class="container">', '' );
 
             $this->widgets( 'full', 'top' );
             $this->header();
@@ -261,6 +264,7 @@
             $this->footer();
             $this->widgets( 'full', 'bottom' );
 
+            $this->output( '</div> <!-- END container -->' );
             $this->output( '</div> <!-- END body-wrapper -->' );
 
             $this->body_suffix();


### PR DESCRIPTION
Hi Ami, I've made a change that fixes some errors coming up in Google's Structured Data Testing Tool. See the [discussion here](https://www.question2answer.org/qa/70061/schema-org-errors-mainentity-missing). Your theme is quite popular and a few people are having problems making the changes themselves.

I've made changes to the Q2A core myself (on the [bugfix](https://github.com/q2a/question2answer/tree/bugfix) branch) but as your theme overrides the relevant functions it requires a change to your theme. This does change the HTML structure slightly - moving the `qa-body-wrapper` div further up so that the page title is inside. So please check it works as you expect (it looked ok to me).